### PR TITLE
update deprecated boost url

### DIFF
--- a/org.opentransactions.metier.json
+++ b/org.opentransactions.metier.json
@@ -10,7 +10,7 @@
       "buildsystem": "simple",
       "sources": [
         {
-          "url": "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2",
+          "url": "https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.bz2",
           "sha256": "71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa",
           "type": "archive"
         }


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
